### PR TITLE
Icon inline + block header fix

### DIFF
--- a/static/css/site.css
+++ b/static/css/site.css
@@ -1,3 +1,13 @@
+/* This pushes other inline elements above or below header */
+div.row h3{
+  width: 100%;
+}
+
+/* Force menu item to be inline to icon */
+.nav-link{
+  display: inline-block !important;
+}
+
 .sps-site-bg-big {
   height: 45vh;
 }


### PR DESCRIPTION
Had an issue where some h3 headers allowed inline items.
Headers should be blocks, not inline.
Had an issue with icons, the menu items were blocks, should be inline with icon.