### PR TITLE
Add site logo to Docs

### DIFF
--- a/layouts/partials/navbar-docs.html
+++ b/layouts/partials/navbar-docs.html
@@ -1,7 +1,7 @@
 {{ $cover := .HasShortcode "blocks/cover" }}
 <nav class="js-navbar-scroll navbar navbar-expand navbar-dark {{ if $cover}} td-navbar-cover {{ end }}flex-column flex-md-row td-navbar">
   <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
-		<span class="font-weight-bold">{{ .Site.Title }}</span>
+	<span class="navbar-logo">{{ if .Site.Params.ui.navbar_logo }}{{ with resources.Get "icons/logo.svg" }}{{ ( . | minify).Content | safeHTML }}{{ end }}{{ end }}</span><span class="font-weight-bold">{{ .Site.Title }}</span>
 	</a>
 	<row class="header-switch">
 	  	<div class="custom-control custom-switch">


### PR DESCRIPTION
When `navbar_logo = true` then the logo should appear on the home nav as well as the docs nav.